### PR TITLE
Support older git versions lacking raw commit body

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function conventionalRecommendedBump(options, parserOpts, cb) {
     }
 
     gitRawCommits({
-      format: '%B%n-hash-%n%H',
+      format: '%s%b%n-hash-%n%H',
       from: tag
     })
       .pipe(conventionalCommitsParser(parserOpts))


### PR DESCRIPTION
Support older git versions (1.7.1 on our server) lacking raw commit body placeholder %B.  %B can be emulated by %s%b.